### PR TITLE
Improve Dockerfile compatibility and performance

### DIFF
--- a/.github/workflows/flake8-pytest.yml
+++ b/.github/workflows/flake8-pytest.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,26 @@
-FROM python:3.12-alpine
+# Use Python 3.12 slim bullseye image for better compatibility and smaller size
+FROM python:3.12-slim-bullseye
 
-WORKDIR ~
-COPY requirements.txt /
-RUN pip install -r /requirements.txt
+# Set the working directory to /app for better organization
+WORKDIR /app
 
-COPY . . 
+# Copy requirements.txt to the container first
+# This allows Docker to cache the installed dependencies for faster builds
+# when your code changes but your dependencies do not
+COPY requirements.txt .
 
+# Install the Python dependencies
+# The --no-cache-dir option is used to keep the image size small
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the code into the container, excluding config.ini
+# Doing this after installing the dependencies allows Docker to cache the
+# installed dependencies separately from your code
+COPY . .
+RUN rm config.ini
+
+# Set the command to run the bot
+# The ENTRYPOINT instruction allows the container to be run as an executable
+# The CMD instruction provides default arguments that can be overridden
 ENTRYPOINT ["python", "bot.py"]
 CMD ["--conf", "config.ini"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a Python script for a Discord bot that uses OpenAI's GPT API to generate
 # Requirements
 
 - Bash
-- Python 3.8 or Higher
+- Python 3.12 or Higher
 - Python Modules
   - discord.py
   - openai

--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ The bot will log in to Discord and start listening for messages in the configure
 
 To run the bot in a container, you will need to check out this repository, rename the `config.ini.example` to `config.ini` and fill it in appropriately.
 Then, run the following commands:
+
 ```bash
 docker build . -t discordianai:latest
-docker run --restart always discordianai:latest
+docker run --restart always -v $(pwd)/config.ini:/app/config.ini discordianai:latest
 ```
-
-This will execute forever, unless manually stopped.
+This will execute forever, unless manually stopped. The `-v` option is used to mount the `config.ini` file from your current directory on the host machine to the `/app/config.ini` file in the Docker container. Replace `$(pwd)/config.ini` with the actual path to your `config.ini` file if it’s not in your current directory. Remember to include the trailing slash in the path. This ensures that Docker treats this as a file and not as a directory.
 
 # Daemon Control Script
 


### PR DESCRIPTION
This Dockerfile now uses the `python:3.12-slim-bullseye` image, which has better compatibility than the alpine image. It also sets the working directory to `/app` for better organization. The `requirements.txt` file is copied separately and the dependencies are installed before the rest of the code is copied over. This allows Docker to cache the installed dependencies for faster builds when your code changes but your dependencies do not. The `--no-cache-dir` option is used with `pip install` to keep the image size small.

Finally, the ENTRYPOINT and CMD instructions are used to run your bot with the specified configuration file. Note that this Dockerfile expects the `config.ini` file to be in the same directory as the Dockerfile. If it’s in a different location, you’ll need to adjust the CMD instruction accordingly. Also, no ports are exposed as per your request.

When you run the Docker image, you can use the `-v` option to mount the `config.ini` file from your host machine to the Docker container.