### PR TITLE
[fix] Ensure config.ini does not exist in Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Doing this after installing the dependencies allows Docker to cache the
 # installed dependencies separately from your code
 COPY . .
-RUN rm config.ini
+RUN if [ -f config.ini ]; then rm config.ini; fi
 
 # Set the command to run the bot
 # The ENTRYPOINT instruction allows the container to be run as an executable


### PR DESCRIPTION
We want to protect against images being built with credentials baked inside of them. If no `config.ini` exists we need to skip the `rm` so that we pass the build step!