### PR TITLE
fix: remove invalid workflow syntax for secrets check

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,7 +79,6 @@ jobs:
 
     - name: Push to Docker Hub (Secondary - Optional)
       uses: docker/build-push-action@v5
-      if: ${{ secrets.DOCKERHUB_TOKEN != '' }}
       with:
         context: .
         platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes the GitHub Actions workflow syntax error that was preventing the Docker build from running.

### What Was Fixed

- **Invalid syntax**: Removed  condition
- **GitHub Actions limitation**: This syntax is not supported for checking if secrets exist
- **Workflow validation**: The workflow now passes syntax validation

### Why This Happened

GitHub Actions doesn't support checking if secrets exist in conditional statements. The Docker Hub push step will now:
- Always attempt to run
- Use  to gracefully handle failures
- Not break the workflow if Docker Hub is down or credentials are missing

### Result

- ✅ Workflow syntax is now valid
- ✅ Docker builds can proceed
- ✅ GHCR remains primary (always reliable)
- ✅ Docker Hub is secondary (optional, won't fail the job)