### PR TITLE
fix: revert to working Python base image for Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-# Use Python 3.10 slim image from GitHub Container Registry (GHCR)
-# This eliminates dependency on Docker Hub entirely
-FROM ghcr.io/docker-library/python:3.10-slim-bookworm
+# Use Python 3.10 slim image (project supports only Python 3.10)
+FROM python:3.10-slim-bookworm
 
 # Set the working directory to /app for better organization
 WORKDIR /app


### PR DESCRIPTION
## Fix for Docker Build Issues

This PR reverts the Python base image to the working version while maintaining all the workflow improvements.

### What Was Fixed

- **Reverted base image**: Back to  (verified working)
- **Maintained workflow improvements**: Dual registry support, graceful failure handling
- **Kept docker-compose.yml**: Production-ready container orchestration

### Why This Fixes the Issue

The previous attempt to use GHCR Python images failed because:
- **GHCR does NOT have Python base images** - they only exist in Docker Hub
- **Base images from Docker Hub are normal and expected** in container builds
- **The workflow improvements are still valuable** for resilience

### What We Keep (Working Improvements)

- ✅ **Dual registry support**: GHCR (primary) + Docker Hub (secondary)
- ✅ **Graceful failure handling**: Docker Hub issues won't break the job
- ✅ **Enhanced workflow**: Retry logic and fallback options
- ✅ **Production docker-compose.yml**: Health checks and resource limits

### Current Status

- **Base image**:  (from Docker Hub - this is normal)
- **Your app image**: Built and pushed to GHCR (eliminates Docker Hub dependency for your app)
- **Workflow**: Resilient to Docker Hub outages while maintaining functionality

### Result

- ✅ Docker builds should now work properly
- ✅ Workflow is resilient to external service issues
- ✅ All containerization benefits are maintained
- ✅ Production deployment is easier with docker-compose.yml

This should finally resolve the Docker build issues while keeping all the valuable workflow improvements.