### PR TITLE
fix: eliminate duplicate builds to resolve false workflow failures

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,7 +60,7 @@ jobs:
           org.opencontainers.image.revision=${{ github.sha }}
           org.opencontainers.image.version=${{ github.ref_name }}
 
-    - name: Build and push to GHCR (Primary)
+    - name: Build and push to both registries
       uses: docker/build-push-action@v5
       with:
         context: .
@@ -72,24 +72,5 @@ jobs:
         cache-to: type=gha,mode=max  # Cache layers for faster builds
         build-args: |
           BUILDKIT_INLINE_CACHE=1
-        # Add retry logic for resilience
-        no-cache-filters: false
-        # Use GitHub's build infrastructure exclusively
+        # Build once, push to both registries
         provenance: false
-
-    - name: Push to Docker Hub (Secondary - Optional)
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        build-args: |
-          BUILDKIT_INLINE_CACHE=1
-        # Continue on failure - this is secondary
-        provenance: false
-      # Continue on failure - Docker Hub is optional
-      continue-on-error: true


### PR DESCRIPTION
## 🐛 Fix for Red Merge Status

This PR fixes the issue where Docker builds were showing as 'failed' even though images were successfully built and pushed to both registries.

### What Was Causing the Problem

The workflow had **two separate build steps**:
1. **Build and push to GHCR** - succeeded ✅
2. **Build and push to Docker Hub** - failed ❌ (duplicate build)

This caused the job to show as 'failed' even though the main goal was achieved.

### What This Fix Does

- **Eliminates duplicate builds**: Single build step instead of two
- **Pushes to both registries**: GHCR and Docker Hub get the same image
- **Resolves false failures**: No more red merge statuses
- **Maintains functionality**: Still pushes to both registries as intended

### Technical Changes

- **Removed duplicate build step** for Docker Hub
- **Single build action** that pushes to both registries
- **Cleaner, more efficient workflow**
- **Eliminates the source of false failures**

### Expected Result

- ✅ **Green merge status** instead of red
- ✅ **Single successful build** 
- ✅ **Push to both registries** (GHCR + Docker Hub)
- ✅ **No more misleading failures**

### Why This Works

The  already configures tags for both registries, so we only need to build once and push to both. This is more efficient and eliminates the duplicate build that was causing failures.

This should finally resolve your red merge status issue while maintaining all the dual registry functionality you want.