### PR TITLE
fix: Update HTTP/2 dependencies to prevent fallback to HTTP/1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.2.7.1] - 2025-09-23
+
+### Fixed
+- **HTTP/2 Dependency Issues**: Fixed production environment HTTP/2 fallback to HTTP/1.1
+  - Updated `httpx[http2]>=0.28.0` and `h2>=4.3.0` in `requirements.txt`
+  - Added HTTP/2 dependencies to `pyproject.toml` for consistency
+  - Enhanced `docs/ConnectionPooling.md` with version requirements and troubleshooting guide
+  - Resolved issue where httpx 0.25.1 had unreliable HTTP/2 support causing fallback
+
+### Documentation
+- **Connection Pooling Guide**: Added comprehensive troubleshooting section for HTTP/2 issues
+- **Version Requirements**: Documented minimum versions for reliable HTTP/2 operation
+- **Installation Commands**: Updated with specific version requirements
+
 ## [v0.2.7] - 2025-01-23
 
 ### Added

--- a/docs/ConnectionPooling.md
+++ b/docs/ConnectionPooling.md
@@ -111,11 +111,18 @@ The connection pool automatically enables HTTP/2 when available:
 ### Requirements
 To enable HTTP/2 support, install the full httpx package:
 ```bash
-pip install httpx[http2]>=0.24.0
+pip install httpx[http2]>=0.28.0 h2>=4.3.0
 ```
+
+**Note**: HTTP/2 support requires httpx 0.28.0+ for reliable operation. Earlier versions may fall back to HTTP/1.1.
 
 ### Troubleshooting HTTP/2
 If you see "HTTP/2 not available" warnings:
-1. Install HTTP/2 dependencies: `pip install httpx[http2]`
+1. Install HTTP/2 dependencies: `pip install httpx[http2]>=0.28.0 h2>=4.3.0`
 2. Restart the bot to enable HTTP/2
 3. Check logs for "HTTP/2 enabled" confirmation
+
+**Common Issues:**
+- **httpx < 0.28.0**: HTTP/2 support is unreliable, upgrade to 0.28.0+
+- **Missing h2 package**: Install with `pip install h2>=4.3.0`
+- **Version conflicts**: Use `pip install --force-reinstall httpx[http2]>=0.28.0 h2>=4.3.0`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "DiscordianAI"
-version = "0.2.7"
+version = "0.2.7.1"
 description = "A Discord bot that uses OpenAI's GPT API to generate responses."
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -15,7 +15,9 @@ dependencies = [
     "openai>=1.101.0",
     "websockets>=15.0.1",
     "requests>=2.31.0",
-    "beautifulsoup4>=4.12.2"
+    "beautifulsoup4>=4.12.2",
+    "httpx[http2]>=0.28.0",
+    "h2>=4.3.0"
 ]
 urls = {"Homepage" = "https://github.com/johndotpub/DiscordianAI"}
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ openai>=1.101.0
 websockets>=15.0.1
 requests>=2.31.0
 beautifulsoup4>=4.12.2
-httpx[http2]>=0.24.0
+httpx[http2]>=0.28.0
+h2>=4.3.0


### PR DESCRIPTION
# 🔧 Fix HTTP/2 Dependency Issues - v0.2.7.1

## 🐛 Problem
Production environment was falling back to HTTP/1.1 despite having HTTP/2 dependencies installed.

## ✅ Solution
- Updated `httpx[http2]>=0.28.0` + `h2>=4.3.0` in requirements.txt
- Added HTTP/2 dependencies to pyproject.toml
- Enhanced ConnectionPooling.md with troubleshooting guide

## 🚀 Results
- ✅ HTTP/2 enabled in production
- ✅ Faster API responses with connection multiplexing
- ✅ Consistent deployments across all environments

## 🔧 Testing
- ✅ Verified HTTP/2 works with updated dependencies
- ✅ All existing tests pass

---

**Ready for v0.2.7.1 release!** 🎉