### PR TITLE
fix: 🔒 upgrade pip before audit + static Ruff badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # Optimized CI workflow with parallel execution and caching
-# Runs tests on Python 3.10 (required), 3.11/3.12 (informational)
+# Runs tests on Python 3.12 (required)
 name: CI
 
 on:
@@ -112,8 +112,11 @@ jobs:
           requirements.txt
           pyproject.toml
 
+    - name: Upgrade pip
+      run: python -m pip install --upgrade pip
+
     - name: Install dependencies and scan
       run: |
         pip install -r requirements.txt
         pip install pip-audit
-        pip-audit --desc
+        pip-audit --desc --progress-spinner=off

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python 3.12+ required](https://img.shields.io/badge/python-3.12%2B-required-3776AB.svg?logo=python&logoColor=white)](https://www.python.org/downloads/)
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![Ruff](https://img.shields.io/badge/linter-ruff-261230.svg)](https://github.com/astral-sh/ruff)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
 
 [![Discord.py](https://img.shields.io/badge/discord.py-2.7.1-5865F2.svg?logo=discord&logoColor=white)](https://discordpy.readthedocs.io/)


### PR DESCRIPTION
## Fixes

- **CI Security Scan**: added explicit `pip install --upgrade pip` step before `pip-audit` so the runner's pre-installed pip (26.0.1 / CVE-2026-3219) no longer triggers a false failure. Also added `--progress-spinner=off` for cleaner logs.
- **README Badge**: replaced flaky endpoint-based Ruff badge with a static shield.

## Files Changed

- `.github/workflows/ci.yml`
- `README.md`
