### PR TITLE
fix: 🔒 classify insufficient_quota as non-retryable and symmetrize retry config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Fixed 🔧
+- Classify OpenAI `insufficient_quota` (429) as non-retryable auth error for instant Perplexity fallback instead of wasteful retry loops.
+- Added `API_TIMEOUT` to non-retryable error list so read timeouts bail immediately to the fallback service rather than compounding retry delays.
+- Symmetrized retry policy across OpenAI and Perplexity: both services now use identical `retry_with_backoff` config (`max_attempts=2`, 2-4s jittered wait, flat delay).
+- Disabled OpenAI SDK-level `max_retries` on both clients to prevent nested retry multiplication (SDK + application wrapper compounding up to 6 calls).
+- Added application-level `retry_with_backoff` wrapper to Perplexity for transient network/5xx resilience (was previously unprotected outside of SDK retries).
+- Increased `httpx.Timeout.read` from 30s to 45s (OpenAI) and 60s (Perplexity) to accommodate high-reasoning and search+citation pipelines.
+
+### Changed 🔁
+- Unified retry wait to 2.0-4.0s flat jittered delay (was 1.0s base with exponential growth up to 30s max_delay).
+
+
 ## [0.2.9.6] - 2026-04-28
 
 ### Fixed 🔧

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -306,7 +306,7 @@ tests/
 └── ...
 ```
 
-**Coverage Target:** 80%+ (enforced by CI)
+**Coverage Target:** 84%+ (enforced by CI)
 
 ## 📁 Project Structure
 

--- a/docs/ConnectionPooling.md
+++ b/docs/ConnectionPooling.md
@@ -126,3 +126,18 @@ If you see "HTTP/2 not available" warnings:
 - **httpx < 0.28.0**: HTTP/2 support is unreliable, upgrade to 0.28.0+
 - **Missing h2 package**: Install with `pip install h2>=4.3.0`
 - **Version conflicts**: Use `pip install --force-reinstall httpx[http2]>=0.28.0 h2>=4.3.0`
+
+## HTTP Timeouts
+
+Each API client uses service-specific read timeouts tuned for their response characteristics:
+
+| Service | Connect | Read | Write | Pool |
+|---------|---------|------|-------|------|
+| **OpenAI** | 10s | 45s | 10s | 5s |
+| **Perplexity** | 10s | 60s | 10s | 5s |
+
+**Rationale:**
+- **OpenAI 45s read**: Handles GPT-5 reasoning on long context without timing out prematurely.
+- **Perplexity 60s read**: Accommodates the full search → analyze → cite pipeline, which can take 30-55s for complex queries.
+- **Connect/write unchanged (10s)**: Network-level operations complete quickly; only inference needs the longer window.
+- **SDK retries disabled**: The OpenAI SDK's built-in `max_retries` is set to `0` on both clients. Application-level retry with jittered backoff is handled by `error_handling.py`'s `retry_with_backoff`, preventing nested retry multiplication.

--- a/docs/HybridMode.md
+++ b/docs/HybridMode.md
@@ -257,9 +257,18 @@ Start your bot and try these examples:
 
 ## Fallback Behavior
 
-If Perplexity is unavailable or not configured:
-- The bot falls back to GPT-5 for all responses
-- You'll see a warning in the logs about web search being disabled
+The hybrid orchestrator (`smart_orchestrator.py`) provides bidirectional fallback between services:
+
+- **OpenAI failure → Perplexity**: When OpenAI returns no response (quota exhaustion, auth errors, timeouts), the orchestrator automatically retries with Perplexity for web-enabled fallback.
+- **Perplexity failure → OpenAI**: When Perplexity fails (network errors, timeouts), the orchestrator falls back to OpenAI for standard completion.
+- **Web-inability reroute**: If OpenAI responds but indicates it cannot browse the web (e.g., "I can't browse the internet"), the orchestrator detects this and reroutes to Perplexity.
+- **Both unavailable**: Returns a user-friendly error message (`"All AI services are temporarily unavailable"`).
+
+Both services share identical retry policy via `retry_with_backoff`:
+- 2 attempts max (1 initial + 1 retry) for transient errors (network blips, 429, 5xx)
+- `insufficient_quota` and `API_TIMEOUT` errors bail immediately — no wasted retries
+- 2.0–4.0s jittered wait between retries to avoid thundering herd
+- SDK-level `max_retries=0` prevents nested retry multiplication
 
 ## Cost Considerations
 

--- a/src/connection_pool.py
+++ b/src/connection_pool.py
@@ -61,10 +61,14 @@ class ConnectionPoolManager:
             max_keepalive_connections=max_keepalive,
         )
 
+        # Perplexity search + citation generation can take longer than standard
+        # chat completions. Use a service-specific read timeout.
+        read_timeout = 60.0 if api_type == "perplexity" else 45.0
+
         # Configure timeouts
         timeout = httpx.Timeout(
             connect=10.0,  # Connection timeout
-            read=30.0,  # Read timeout
+            read=read_timeout,
             write=10.0,  # Write timeout
             pool=5.0,  # Pool timeout
         )
@@ -131,12 +135,14 @@ class ConnectionPoolManager:
             api_key=api_key,
             base_url=base_url,
             http_client=http_client,
+            max_retries=0,
         )
 
         self._logger.debug(
             "Created OpenAI client with connection pooling for %s "
             "(max_connections=%d, "
-            "max_keepalive=%d)",
+            "max_keepalive=%d, "
+            "max_retries=0)",
             base_url,
             self.openai_max_connections,
             self.openai_max_keepalive,
@@ -166,12 +172,14 @@ class ConnectionPoolManager:
             api_key=api_key,
             base_url=base_url,
             http_client=http_client,
+            max_retries=0,
         )
 
         self._logger.debug(
             "Created Perplexity client with connection pooling for %s "
             "(max_connections=%d, "
-            "max_keepalive=%d)",
+            "max_keepalive=%d, "
+            "max_retries=0)",
             base_url,
             self.perplexity_max_connections,
             self.perplexity_max_keepalive,

--- a/src/error_handling.py
+++ b/src/error_handling.py
@@ -166,7 +166,11 @@ async def retry_with_backoff(
             error_details = classify_error(e)
 
             # Don't retry certain error types
-            if error_details.error_type in [ErrorType.API_AUTH_ERROR, ErrorType.CONFIG_ERROR]:
+            if error_details.error_type in [
+                ErrorType.API_AUTH_ERROR,
+                ErrorType.API_TIMEOUT,
+                ErrorType.CONFIG_ERROR,
+            ]:
                 logger.exception("Non-retryable error in %s", func.__name__)
                 raise
 
@@ -223,8 +227,17 @@ def classify_error(exception: Exception) -> ErrorDetails:
     user_message = "An unexpected error occurred. Please try again."
     retry_after = None
 
+    # Permanent billing/quota exhaustion — not a transient rate limit
+    if (
+        "insufficient_quota" in error_msg.lower()
+        or "exceeded your current quota" in error_msg.lower()
+    ):
+        error_type = ErrorType.API_AUTH_ERROR
+        severity = ErrorSeverity.HIGH
+        user_message = "💳 API quota exhausted. Please check your OpenAI plan and billing details."
+
     # OpenAI/API specific errors
-    if "rate limit" in error_msg.lower() or "429" in error_msg:
+    elif "rate limit" in error_msg.lower() or "429" in error_msg:
         error_type = ErrorType.API_RATE_LIMIT
         severity = ErrorSeverity.MEDIUM
         user_message = "⏱️ Service is busy. Please try again in a moment."

--- a/src/openai_processing.py
+++ b/src/openai_processing.py
@@ -37,7 +37,9 @@ async def _fetch_openai_response(
         async def api_call_with_retry():
             return await openai_client.chat.completions.create(**api_params)
 
-        retry_config = RetryConfig(max_attempts=2, base_delay=1.0, max_delay=30.0)
+        retry_config = RetryConfig(
+            max_attempts=2, base_delay=4.0, max_delay=4.0, exponential_base=1.0, jitter=True
+        )
 
         try:
             response = await retry_with_backoff(api_call_with_retry, retry_config, request.logger)

--- a/src/perplexity_processing.py
+++ b/src/perplexity_processing.py
@@ -18,6 +18,7 @@ from .config import (
     URL_PATTERN,
 )
 from .discord_embeds import citation_embed_formatter
+from .error_handling import RetryConfig, retry_with_backoff
 from .models import AIRequest, PerplexityConfig
 from .web_scraper import is_scrapable_url, scrape_url_content
 
@@ -242,7 +243,16 @@ async def process_perplexity_message(
                 request.message, urls_in_message, request.logger
             )
 
-        response = await perplexity_client.chat.completions.create(**api_params)
+        async def _call_perplexity():
+            return await perplexity_client.chat.completions.create(**api_params)
+
+        response = await retry_with_backoff(
+            _call_perplexity,
+            RetryConfig(
+                max_attempts=2, base_delay=4.0, max_delay=4.0, exponential_base=1.0, jitter=True
+            ),
+            request.logger,
+        )
         return _handle_api_response(response, request, urls_in_message, api_params, config)
 
     except TimeoutError:

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -124,6 +124,7 @@ class TestConnectionPoolManager:
                 api_key="test-key",
                 base_url="https://api.openai.com/v1/",
                 http_client=mock_http_instance,
+                max_retries=0,
             )
 
     @patch("src.connection_pool.httpx.AsyncClient")
@@ -147,6 +148,7 @@ class TestConnectionPoolManager:
                 api_key="test-key",
                 base_url="https://api.perplexity.ai",
                 http_client=mock_http_instance,
+                max_retries=0,
             )
 
 

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -382,6 +382,25 @@ class TestRetryWithBackoff:
         assert call_count == 1
         mock_logger.exception.assert_called_once()
 
+    async def test_retry_skips_api_timeout_errors(self):
+        """Test that API_TIMEOUT is not retried (fails fast to fallback)."""
+        call_count = 0
+
+        async def test_func():
+            nonlocal call_count
+            call_count += 1
+            msg = "Request timed out after 30 seconds"
+            raise Exception(msg)
+
+        mock_logger = Mock()
+        config = RetryConfig(max_attempts=3, base_delay=0.1)
+
+        with pytest.raises(Exception, match="timed out"):
+            await retry_with_backoff(test_func, config, mock_logger)
+
+        assert call_count == 1
+        mock_logger.exception.assert_called_once()
+
 
 class TestClassifyError:
     """Test error classification functionality."""
@@ -394,6 +413,29 @@ class TestClassifyError:
         assert details.error_type == ErrorType.API_RATE_LIMIT
         assert details.severity == ErrorSeverity.MEDIUM
         assert "service is busy" in details.user_message.lower()
+
+    def test_classify_insufficient_quota_error(self):
+        """Test classification of permanent quota exhaustion as auth error."""
+        error = Exception(
+            "Error code: 429 - insufficient_quota: "
+            "You exceeded your current quota, please check your plan and billing details."
+        )
+        details = classify_error(error)
+
+        assert details.error_type == ErrorType.API_AUTH_ERROR
+        assert details.severity == ErrorSeverity.HIGH
+        assert "quota exhausted" in details.user_message.lower()
+
+    def test_classify_exceeded_quota_variant(self):
+        """Test classification of 'exceeded your current quota' phrasing."""
+        error = Exception(
+            "429 - {'error': {'message': 'You exceeded your current quota, "
+            "please check your plan and billing details.'}}"
+        )
+        details = classify_error(error)
+
+        assert details.error_type == ErrorType.API_AUTH_ERROR
+        assert details.severity == ErrorSeverity.HIGH
 
     def test_classify_api_timeout_error(self):
         """Test classification of timeout errors."""


### PR DESCRIPTION
## Summary

Production logs from 2026-05-02 revealed three issues with API retry and fallback behavior after the v0.2.9.6 hardening changes:

1. **OpenAI `insufficient_quota` (HTTP 429) wasted retries**: `classify_error()` treated all 429s as transient `API_RATE_LIMIT`. Permanent billing exhaustion retried for ~5-8s before Perplexity fallback kicked in.
2. **Perplexity had zero application-level retry**: A single `ConnectTimeout` killed the call — only SDK-level retries provided any resilience.
3. **SDK retries compounded with application retries**: OpenAI SDK's `max_retries=2` + our `retry_with_backoff(max_attempts=2)` produced up to 6 API calls.

## Changes

### 🔧 Fixed

| File | Change |
|------|--------|
| `src/error_handling.py` | `classify_error()`: detect `insufficient_quota` / `exceeded your current quota` as `API_AUTH_ERROR` (non-retryable, severity HIGH) **before** generic `429` check |
| `src/error_handling.py` | Add `API_TIMEOUT` to `retry_with_backoff`'s non-retryable list so read timeouts bail immediately to fallback |
| `src/connection_pool.py` | Disable SDK `max_retries=0` on both clients to prevent nested retry multiplication |
| `src/openai_processing.py` | Update `RetryConfig` to flat jittered delay: `max_attempts=2, base_delay=4.0, max_delay=4.0, exponential_base=1.0, jitter=True` |
| `src/perplexity_processing.py` | Add `retry_with_backoff` wrapper with same config (previously unprotected outside SDK retries) |
| `src/connection_pool.py` | Bump `httpx.Timeout.read`: OpenAI 30s→45s, Perplexity 30s→60s for high-reasoning pipelines |

### 🔁 Changed

- Unified retry wait to 2.0–4.0s flat jittered delay (was 1.0s base with exponential growth up to 30s max_delay)
- Both services now use identical retry policy — full symmetry

### ✅ Tests

- 2 new test cases in `TestClassifyError`: `test_classify_insufficient_quota_error`, `test_classify_exceeded_quota_variant`
- 1 new test case in `TestRetryWithBackoff`: `test_retry_skips_api_timeout_errors`
- Updated 2 assertion call signatures in `TestConnectionPoolManager` for `max_retries=0`

### 📝 Documentation

- `docs/Architecture.md`: updated coverage target 80%→84%
- `docs/ConnectionPooling.md`: added HTTP Timeouts section with service-specific table
- `docs/HybridMode.md`: expanded Fallback Behavior section with bidirectional fallback, retry policy, and web-inability reroute details
- `CHANGELOG.md`: added `[Unreleased]` section

## Test Results

```
tox -e py312  : 587 passed, 87.06% coverage (>84% gate)
black --check . : All done! ✨ 🍰 ✨ 55 files left unchanged
ruff check .   : All checks passed!
tox -e audit   : No known vulnerabilities found
```

## Post-Fix Behavior

| | OpenAI | Perplexity |
|---|---|---|
| SDK `max_retries` | 0 | 0 |
| Our `max_attempts` | 2 (timeout = 1) | 2 (timeout = 1) |
| Jittered wait | 2.0–4.0s | 2.0–4.0s |
| `read` timeout | 45s | 60s |
| `insufficient_quota` | Instant fail → Perplexity fallback | Instant fail → OpenAI fallback |

Both services fully symmetrical. Quota exhaustion bails in ~0s. Timeouts bail after single attempt. Transient errors get 1 retry with 2-4s random wait.