### PR TITLE
fix: rewrite discordian.sh launcher for portability and reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bender.ini*
 nohup.out
 bot.log
 test.log
+.bot.pid
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed 🔧
+- **discordian.sh launcher rewrite**: Fixed `ModuleNotFoundError: No module named 'src'` when running from cron — the script now always `cd`s into the project directory before launching Python.
+- **Python resolution**: Removed hardcoded linuxbrew PATH. The launcher now resolves Python in a portable priority order: pyenv → project venv → shell venv → system `python3`.
+- **Venv bootstrapping**: Automatically creates a project-local `.venv/` with dependencies if one doesn't exist, using the resolved Python interpreter.
+- **Process management**: Replaced bare `pkill` with PID-file based shutdown (SIGTERM → 10s wait → SIGKILL) and stray process cleanup.
+- **Startup health check**: Daemon mode now waits 3 seconds after launch and confirms the process survived before reporting success.
+- **Version gating**: Added Python ≥3.12 check with a clear error message on older interpreters.
+
+### Added ✨
+- **`--install-systemd` flag** on `discordian.sh`: generates and installs a systemd user service from a config file name (e.g., `./discordian.sh --install-systemd bot.ini` creates `discordian-bot@bot.service`). Auto-detects paths, builds PATH dynamically from pyenv and Homebrew (via `brew --prefix`), and enables the service.
+- **systemd template unit** (`contrib/systemd/discordian-bot@.service`): reference template for manual setup. Instance name maps to config file (`discordian-bot@bot` → `bot.ini`).
+- **docs/Daemon.md**: rewritten with both cron and systemd deployment paths, `--install-systemd` quick-setup, Python resolution order (pyenv first), venv bootstrapping guide, and troubleshooting section.
+- **README.md**: added "Running with the launcher script" section with usage examples including `--install-systemd`.
+- **`.bot.pid` gitignore**: added PID file to `.gitignore`.
+
+---
+
+### Fixed 🔧
 - Classify OpenAI `insufficient_quota` (429) as non-retryable auth error for instant Perplexity fallback instead of wasteful retry loops.
 - Added `API_TIMEOUT` to non-retryable error list so read timeouts bail immediately to the fallback service rather than compounding retry delays.
 - Symmetrized retry policy across OpenAI and Perplexity: both services now use identical `retry_with_backoff` config (`max_attempts=2`, 2-4s jittered wait, flat delay).

--- a/README.md
+++ b/README.md
@@ -58,6 +58,28 @@ python -m src.main --conf config.ini --folder /path/to/base/folder
 - `--conf` points at the config file.
 - `--folder` (optional) makes config/log paths relative to a base directory (useful for Docker or systemd units).
 
+### Running with the launcher script
+
+The included `discordian.sh` script handles Python environment resolution, venv bootstrapping, and process management automatically:
+
+```bash
+# Foreground (development)
+./discordian.sh -c config.ini
+
+# Daemon mode (cron, background)
+./discordian.sh -d -c config.ini
+
+# Specify project directory explicitly
+./discordian.sh -d -c production.ini -f /opt/discordianai
+
+# Install a systemd service (auto-detects paths)
+./discordian.sh --install-systemd bot.ini
+```
+
+The launcher resolves Python in this order: pyenv → project-local `.venv` → shell venv → system `python3`. It creates a `.venv/` automatically if none exists. It also ensures the working directory is correct — no more `ModuleNotFoundError: No module named 'src'` when running from cron.
+
+`--install-systemd` generates a complete systemd user unit from the config file name (e.g., `bot.ini` → `discordian-bot@bot.service`), writes it to `~/.config/systemd/user/`, enables it, and prints management commands. See [docs/Daemon.md](docs/Daemon.md) for both cron and systemd setup.
+
 ## Configuration Essentials
 
 | Key | Purpose |

--- a/contrib/systemd/discordian-bot@.service
+++ b/contrib/systemd/discordian-bot@.service
@@ -1,0 +1,56 @@
+# DiscordianAI — systemd user service template
+#
+# RECOMMENDED: Use the launcher's --install-systemd flag instead of
+# copying this file manually. It auto-detects paths and generates
+# a correct, ready-to-run unit file:
+#
+#   ./discordian.sh --install-systemd bot.ini
+#
+# That command creates ~/.config/systemd/user/discordian-bot@bot.service
+# with all paths filled in from the script's actual location, enables
+# it, and prints management commands.
+#
+# MANUAL SETUP: If you prefer to install by hand:
+#
+#   1. Copy this file to ~/.config/systemd/user/
+#   2. Edit the copy: replace all /path/to/DiscordianAI with your
+#      actual installation path
+#   3. Adjust PATH to include pyenv or Homebrew if needed
+#      (the --install-systemd flag does this automatically)
+#   4. Reload and enable:
+#        systemctl --user daemon-reload
+#        systemctl --user enable --now discordian-bot@bot
+#
+# The instance name (%i) becomes the config file name:
+#   discordian-bot@bot      → bot.ini
+#   discordian-bot@prod     → prod.ini
+#   discordian-bot@staging  → staging.ini
+
+[Unit]
+Description=DiscordianAI Bot (%i)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/path/to/DiscordianAI/discordian.sh -c %i.ini -f /path/to/DiscordianAI
+WorkingDirectory=/path/to/DiscordianAI
+Restart=on-failure
+RestartSec=15
+
+StandardOutput=append:/path/to/DiscordianAI/bot.log
+StandardError=append:/path/to/DiscordianAI/bot.log
+
+# Adjust PATH to include pyenv/Homebrew/python as needed for your system.
+# The --install-systemd flag auto-detects these paths.
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=HOME=%h
+Environment=LANG=en_US.UTF-8
+
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/path/to/DiscordianAI
+
+[Install]
+WantedBy=default.target

--- a/discordian.sh
+++ b/discordian.sh
@@ -1,110 +1,300 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# DiscordianAI Launcher — portable, venv-aware, pyenv-friendly
+#
+# Suitable for manual execution, crontab, or systemd (foreground mode).
+# Always changes directory to the project root before launching,
+# so Python can find the `src` package regardless of how it's invoked.
+#
+# Usage:
+#   ./discordian.sh                          # foreground, default config
+#   ./discordian.sh -d                       # daemon mode (background)
+#   ./discordian.sh -c bot.ini               # custom config file
+#   ./discordian.sh -f /path/to/project      # project directory
+#   ./discordian.sh -d -c production.ini -f /opt/discordianai
+#   ./discordian.sh --install-systemd bot.ini # install and enable systemd service
+#
+# Python resolution order:
+#   1. pyenv-managed python3 (preferred — version-pinned, reproducible)
+#   2. Project-local .venv/bin/python3
+#   3. Shell-activated venv ($VIRTUAL_ENV)
+#   4. System python3
+#
+# If no venv exists, one is created automatically in the project directory.
 
-# Ensure linuxbrew/python3 is in PATH for cron environments
-export PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+set -euo pipefail
 
-# Script for launching a DiscordianAI bot with customizable configurations.
-# Suitable for both manual execution and running via crontab.
+# ── Defaults ──────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+CONFIG_FILE="bot.ini"
+DAEMON_MODE=false
+PROJECT_DIR="${SCRIPT_DIR}"
+INSTALL_SYSTEMD=""
 
-# Enable strict error checking: Exit on any error and recognize failures in pipelines.
-set -e
-set -o pipefail
-
-# Logging function with timestamp for better tracking
-log() {
-    echo "$(date '+%Y-%m-%d %H:%M:%S') - $1"
-}
-
-# Find and log the path to the python3 executable.
-python3="$(which python3)"
-log "Using python3 binary: $python3"
-
-# Default configuration and output settings
-config_file="bot.ini"  # Default configuration file.
-output=""              # No output redirection initially.
-base_folder=""         # Use current directory by default.
-
-# Process command line arguments to adjust script settings
+# ── Argument parsing ──────────────────────────────────────────────────
 while [[ "$#" -gt 0 ]]; do
     case "$1" in
-        -d|--daemon)
-            # Daemon mode: No output to terminal
-            output="/dev/null"
-            log "Running in daemon mode. Output redirected to $output"
-            ;;
+        -d|--daemon) DAEMON_MODE=true; shift ;;
         -c|--config)
-            # Custom configuration file: Ensure argument is provided
-            if [[ -n "$2" && ! "$2" =~ ^- ]]; then
-                config_file="$2"
-                shift  # Skip next argument
-                log "Using custom config file: $config_file"
-            else
-                log "Error: Configuration file argument required."
-                exit 1
-            fi
-            ;;
+            [[ -n "${2:-}" && ! "$2" =~ ^- ]] || { echo "ERROR: -c requires a config file argument" >&2; exit 1; }
+            CONFIG_FILE="$2"; shift 2 ;;
         -f|--folder)
-            # Base folder: Ensure argument is a valid path
-            if [[ -n "$2" && ! "$2" =~ ^- ]]; then
-                base_folder="$(realpath "$2")"
-                shift  # Skip next argument
-                log "Using base folder: $base_folder"
-            else
-                log "Error: Folder path argument required."
-                exit 1
-            fi
-            ;;
-        *)
-            # Ignore unrecognized options
-            ;;
+            [[ -n "${2:-}" && ! "$2" =~ ^- ]] || { echo "ERROR: -f requires a directory argument" >&2; exit 1; }
+            PROJECT_DIR="$(realpath "$2")"; shift 2 ;;
+        --install-systemd)
+            [[ -n "${2:-}" && ! "$2" =~ ^- ]] || { echo "ERROR: --install-systemd requires a config file argument" >&2; exit 1; }
+            INSTALL_SYSTEMD="$2"; shift 2 ;;
+        -h|--help)
+            echo "Usage: $0 [-d] [-c config.ini] [-f /path/to/project]"
+            echo "       $0 --install-systemd config.ini"
+            echo ""
+            echo "  -d, --daemon            Run in background (daemon mode)"
+            echo "  -c, --config            Configuration file (default: bot.ini)"
+            echo "  -f, --folder            Project directory (default: script location)"
+            echo "      --install-systemd   Generate and install a systemd user service for"
+            echo "                          the given config file, then exit"
+            echo "  -h, --help              Show this help message"
+            exit 0 ;;
+        *) shift ;;
     esac
-    shift  # Move to next argument
 done
 
-# Construct the command with the base folder and config file.
-# If base_folder is set, prepend it to both bot.py and config file paths.
-if [[ -n $base_folder ]]; then
-    command="$python3 -m src.main --conf $config_file --folder $base_folder"
-else
-    command="$python3 -m src.main --conf $config_file"
-fi
-log "Command to execute: $command"
+VENV_DIR="${PROJECT_DIR}/.venv"
+PID_FILE="${PROJECT_DIR}/.bot.pid"
+LOG_FILE="${PROJECT_DIR}/bot.log"
 
-# Enhanced error handling
-trap 'log "An error occurred. Exiting..."; exit 1' ERR
+# ── systemd installation ─────────────────────────────────────────────
+#     Generates a unit file from the config file name and installs it.
+#     The config file (e.g. bot.ini) becomes the systemd instance name
+#     (discordian-bot@bot). All paths are resolved from the script location.
+if [[ -n "${INSTALL_SYSTEMD}" ]]; then
+    # Derive instance name from config file (bot.ini → bot)
+    INSTANCE="$(basename "${INSTALL_SYSTEMD}" .ini)"
+    CONFIG_FILE="${INSTALL_SYSTEMD}"
+    UNIT_NAME="discordian-bot@${INSTANCE}.service"
+    UNIT_DIR="${HOME}/.config/systemd/user"
+    UNIT_FILE="${UNIT_DIR}/${UNIT_NAME}"
 
-# Terminate existing instances of the bot
-log "Killing existing instances of the bot..."
-pkill -f "src.main --conf" || true
-
-# Check dependencies before starting
-log "Checking dependencies..."
-if [[ -n $base_folder ]]; then
-    dep_check_cmd="$python3 -c \"import sys; sys.path.insert(0, '$base_folder'); from src.dependency_check import check_dependencies; success, missing = check_dependencies(); exit(0 if success else 1)\""
-else
-    dep_check_cmd="$python3 -c \"from src.dependency_check import check_dependencies; success, missing = check_dependencies(); exit(0 if success else 1)\""
-fi
-
-if ! eval "$dep_check_cmd" 2>/dev/null; then
-    log "ERROR: Dependency check failed. Please install missing packages."
-    log "Run: pip install -r requirements.txt"
-    exit 1
-fi
-log "✓ All dependencies available"
-
-# Decide execution mode based on output setting
-if [[ -z $output ]]; then
-    # Normal execution
-    eval "$command"
-else
-    # Daemon execution — log output instead of /dev/null so crashes are visible
-    logfile="${base_folder:-.}/bot.log"
-    log "Running command in background: $command >> $logfile 2>&1 &"
-    if ! ($command >> "$logfile" 2>&1 &); then
-        log "Error: Failed to execute command."
+    # Verify config exists
+    CONFIG_PATH="${PROJECT_DIR}/${CONFIG_FILE}"
+    if [[ ! -f "${CONFIG_PATH}" ]]; then
+        echo "ERROR: Config file not found: ${CONFIG_PATH}" >&2
         exit 1
     fi
+
+    # Build PATH env for the systemd unit — detect pyenv and homebrew dynamically
+    UNIT_PATH=""
+    # pyenv
+    [[ -d "${HOME}/.pyenv/shims" ]] && UNIT_PATH="${HOME}/.pyenv/shims:"
+    [[ -d "${HOME}/.pyenv/bin" ]] && UNIT_PATH="${UNIT_PATH}${HOME}/.pyenv/bin:"
+    # Homebrew — detect prefix from brew if available, else check standard locations
+    if command -v brew >/dev/null 2>&1; then
+        BREW_PREFIX="$(brew --prefix 2>/dev/null)"
+        if [[ -n "${BREW_PREFIX}" && -d "${BREW_PREFIX}/bin" ]]; then
+            UNIT_PATH="${UNIT_PATH}${BREW_PREFIX}/bin:${BREW_PREFIX}/sbin:"
+        fi
+    else
+        # Fallback: check standard Homebrew locations
+        for brew_dir in /home/linuxbrew/.linuxbrew /opt/homebrew "/usr/local/Homebrew" "${HOME}/.linuxbrew"; do
+            if [[ -d "${brew_dir}/bin" ]]; then
+                UNIT_PATH="${UNIT_PATH}${brew_dir}/bin:${brew_dir}/sbin:"
+            fi
+        done
+    fi
+    UNIT_PATH="${UNIT_PATH}/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+    mkdir -p "${UNIT_DIR}"
+    cat > "${UNIT_FILE}" <<EOF
+[Unit]
+Description=DiscordianAI Bot (${INSTANCE})
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${SCRIPT_DIR}/discordian.sh -c ${CONFIG_FILE} -f ${PROJECT_DIR}
+WorkingDirectory=${PROJECT_DIR}
+Restart=on-failure
+RestartSec=15
+
+StandardOutput=append:${PROJECT_DIR}/bot.log
+StandardError=append:${PROJECT_DIR}/bot.log
+
+Environment=PATH=${UNIT_PATH}
+Environment=HOME=${HOME}
+Environment=LANG=en_US.UTF-8
+
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=${PROJECT_DIR}
+
+[Install]
+WantedBy=default.target
+EOF
+
+    echo "Generated: ${UNIT_FILE}"
+    systemctl --user daemon-reload
+    systemctl --user enable "${UNIT_NAME}"
+    echo ""
+    echo "Service installed and enabled. Manage with:"
+    echo "  systemctl --user start ${UNIT_NAME}"
+    echo "  systemctl --user status ${UNIT_NAME}"
+    echo "  journalctl --user -u ${UNIT_NAME} -f"
+    echo ""
+    echo "To uninstall:"
+    echo "  systemctl --user disable ${UNIT_NAME}"
+    echo "  rm ${UNIT_FILE}"
+    echo "  systemctl --user daemon-reload"
+    exit 0
 fi
 
-# Log successful execution completion
-log "Script execution completed successfully."
+# ── Logging ───────────────────────────────────────────────────────────
+log() { printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1"; }
+
+# ── 1. Change to project directory ────────────────────────────────────
+#     Cron runs from $HOME — Python needs CWD inside the project to
+#     find the `src` package via `-m src.main`.
+cd "${PROJECT_DIR}"
+log "Working directory: $(pwd)"
+
+# ── 2. Resolve Python interpreter ─────────────────────────────────────
+#     Priority: pyenv → project venv → shell venv → system python3
+resolve_python() {
+    # pyenv first — version-pinned, reproducible
+    if command -v pyenv >/dev/null 2>&1; then
+        local pyenv_python
+        pyenv_python="$(pyenv which python3 2>/dev/null || true)"
+        if [[ -n "${pyenv_python}" && -x "${pyenv_python}" ]]; then
+            echo "${pyenv_python}"
+            return 0
+        fi
+    fi
+    # Project-local venv
+    if [[ -x "${VENV_DIR}/bin/python3" ]]; then
+        echo "${VENV_DIR}/bin/python3"
+        return 0
+    fi
+    # Shell-activated venv (VIRTUAL_ENV is set)
+    if [[ -n "${VIRTUAL_ENV:-}" && -x "${VIRTUAL_ENV}/bin/python3" ]]; then
+        echo "${VIRTUAL_ENV}/bin/python3"
+        return 0
+    fi
+    # System python3
+    local sys_python
+    sys_python="$(command -v python3 2>/dev/null || true)"
+    if [[ -n "${sys_python}" ]]; then
+        echo "${sys_python}"
+        return 0
+    fi
+    return 1
+}
+
+PYTHON="$(resolve_python)" || {
+    log "ERROR: No python3 found. Install Python 3.12+ or create a venv."
+    exit 1
+}
+log "Using python3: ${PYTHON} ($(${PYTHON} --version 2>&1))"
+
+# ── 3. Verify Python version (3.12+) ──────────────────────────────────
+py_major="$(${PYTHON} -c 'import sys; print(sys.version_info[0])')"
+py_minor="$(${PYTHON} -c 'import sys; print(sys.version_info[1])')"
+if [[ "${py_major}" -lt 3 ]] || [[ "${py_major}" -eq 3 && "${py_minor}" -lt 12 ]]; then
+    log "ERROR: Python 3.12+ required, found ${py_major}.${py_minor}"
+    exit 1
+fi
+
+# ── 4. Bootstrap venv if missing ──────────────────────────────────────
+if [[ ! -d "${VENV_DIR}" || ! -x "${VENV_DIR}/bin/python3" ]]; then
+    log "Creating venv at ${VENV_DIR} using ${PYTHON}..."
+    "${PYTHON}" -m venv "${VENV_DIR}" || {
+        log "ERROR: Failed to create venv. Check Python installation."
+        exit 1
+    }
+    log "Installing dependencies..."
+    if [[ -f "${PROJECT_DIR}/requirements.txt" ]]; then
+        "${VENV_DIR}/bin/pip" install -r "${PROJECT_DIR}/requirements.txt" --quiet 2>/dev/null || {
+            log "WARNING: pip install reported issues, retrying with verbose output..."
+            "${VENV_DIR}/bin/pip" install -r "${PROJECT_DIR}/requirements.txt"
+        }
+    elif [[ -f "${PROJECT_DIR}/pyproject.toml" ]]; then
+        "${VENV_DIR}/bin/pip" install -e "${PROJECT_DIR}" --quiet 2>/dev/null || {
+            log "WARNING: pip install reported issues, retrying with verbose output..."
+            "${VENV_DIR}/bin/pip" install -e "${PROJECT_DIR}"
+        }
+    else
+        log "WARNING: No requirements.txt or pyproject.toml found — dependencies may be missing."
+    fi
+    log "Venv bootstrapped successfully."
+    # Re-resolve to the venv python
+    PYTHON="${VENV_DIR}/bin/python3"
+fi
+
+# ── 5. Dependency check ───────────────────────────────────────────────
+log "Checking core dependencies..."
+if ! "${PYTHON}" -c "import discord; import openai; import httpx" 2>/dev/null; then
+    log "ERROR: Missing core dependencies (discord.py, openai, or httpx)."
+    log "Repair with: ${VENV_DIR}/bin/pip install -r requirements.txt"
+    exit 1
+fi
+log "✓ All core dependencies available"
+
+# ── 6. Kill existing instances (cron restart) ──────────────────────────
+log "Stopping any existing instances..."
+my_pid="$$"
+
+# By PID file
+if [[ -f "${PID_FILE}" ]]; then
+    old_pid="$(cat "${PID_FILE}")"
+    if [[ -n "${old_pid}" ]] && kill -0 "${old_pid}" 2>/dev/null; then
+        log "Stopping previous instance (PID ${old_pid})"
+        kill "${old_pid}" 2>/dev/null || true
+        local_wait=0
+        while kill -0 "${old_pid}" 2>/dev/null && [[ ${local_wait} -lt 10 ]]; do
+            sleep 1; ((local_wait++))
+        done
+        if kill -0 "${old_pid}" 2>/dev/null; then
+            log "Force-killing unresponsive process ${old_pid}"
+            kill -9 "${old_pid}" 2>/dev/null || true
+        fi
+    fi
+    rm -f "${PID_FILE}"
+fi
+
+# Stragglers matching the bot pattern (but not ourselves)
+for pid in $(pgrep -f "src.main.*--conf" 2>/dev/null || true); do
+    if [[ "${pid}" != "${my_pid}" ]]; then
+        log "Killing stray process ${pid}"
+        kill "${pid}" 2>/dev/null || true
+    fi
+done
+
+# ── 7. Build and launch the command ────────────────────────────────────
+CMD_ARGS=(-m src.main --conf "${CONFIG_FILE}")
+if [[ "${PROJECT_DIR}" != "$(pwd)" ]]; then
+    CMD_ARGS+=(--folder "${PROJECT_DIR}")
+fi
+log "Command: ${PYTHON} ${CMD_ARGS[*]}"
+
+if [[ "${DAEMON_MODE}" == true ]]; then
+    # ── Daemon mode: background, redirect to log file ──────────────────
+    log "Daemon mode: logging to ${LOG_FILE}"
+    nohup "${PYTHON}" "${CMD_ARGS[@]}" >> "${LOG_FILE}" 2>&1 &
+    bot_pid=$!
+    echo "${bot_pid}" > "${PID_FILE}"
+    log "Bot started in background (PID ${bot_pid})"
+
+    # Health check: give it a few seconds to crash on startup
+    sleep 3
+    if kill -0 "${bot_pid}" 2>/dev/null; then
+        log "✓ Bot is running (PID ${bot_pid})"
+    else
+        log "ERROR: Bot crashed on startup. Check ${LOG_FILE}"
+        rm -f "${PID_FILE}"
+        exit 1
+    fi
+else
+    # ── Foreground mode: systemd or manual ────────────────────────────
+    echo "$$" > "${PID_FILE}"
+    log "Running in foreground (PID $$)"
+    exec "${PYTHON}" "${CMD_ARGS[@]}"
+fi

--- a/discordian.sh
+++ b/discordian.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Define PATH if running from crontab. Adjust as necessary.
-# PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# Ensure linuxbrew/python3 is in PATH for cron environments
+export PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # Script for launching a DiscordianAI bot with customizable configurations.
 # Suitable for both manual execution and running via crontab.
@@ -97,9 +97,10 @@ if [[ -z $output ]]; then
     # Normal execution
     eval "$command"
 else
-    # Daemon execution
-    log "Running command in background: $command > $output 2>&1 &"
-    if ! ($command > "$output" 2>&1 &); then
+    # Daemon execution — log output instead of /dev/null so crashes are visible
+    logfile="${base_folder:-.}/bot.log"
+    log "Running command in background: $command >> $logfile 2>&1 &"
+    if ! ($command >> "$logfile" 2>&1 &); then
         log "Error: Failed to execute command."
         exit 1
     fi

--- a/docs/Daemon.md
+++ b/docs/Daemon.md
@@ -1,29 +1,201 @@
 # Daemon Control Script
 
-`discordian.sh` is a bash script for launching a DiscordianAI bot with customizable configurations. It is suitable for both manual execution and running via crontab.
+`discordian.sh` is a bash launcher for DiscordianAI that handles Python environment resolution, dependency verification, and process management. It works for manual execution, cron scheduling, and systemd services.
 
-### Features
+## Features
 
-- Strict error checking: The script exits on any error and recognizes failures in pipelines.
-- Logging: The script logs events with timestamps for better tracking.
-- Customizable configurations: The script allows for different modes of operation and configurations.
-- Error Handling: It logs errors and exits on failure.
-- Process Handling: It terminates existing instances of the bot before starting a new one.
+- **Automatic Python resolution**: Finds the right Python interpreter via pyenv → project venv → shell venv → system path (pyenv preferred for version pinning)
+- **Venv bootstrapping**: Creates and populates a project-local `.venv/` if one doesn't exist
+- **Correct working directory**: Always changes to the project root, so `python -m src.main` works regardless of where the script is invoked from (including cron's `$HOME`)
+- **Process management**: Stops previous instances before starting, with graceful shutdown and forced kill fallback
+- **Daemon and foreground modes**: Background mode for cron, foreground mode for systemd
+- **Startup health check**: In daemon mode, waits 3 seconds and confirms the process survived
+- **systemd installation**: `--install-systemd bot.ini` generates a ready-to-run user service unit with all paths auto-detected
 
-### Usage
+## Requirements
 
-The script accepts the following command line arguments:
+- **Python 3.12 or newer** (project requirement)
+- Bash 4+ (for `set -euo pipefail`, `[[ ]]` conditionals)
+- `pgrep` for process management (available on most Linux/macOS systems)
 
-- `-d` or `--daemon`: Runs the bot in daemon mode with no output to the terminal.
-- `-c` or `--config`: Allows the use of a custom configuration file. The next argument should be the path to the configuration file.
-- `-f` or `--folder`: Allows the use of a base folder. The next argument should be the path to the base folder.
+## Python Resolution Order
 
-### Daemon Example
+The launcher resolves the Python interpreter in this priority:
+
+1. **pyenv** — Whatever `pyenv which python3` resolves for the project directory
+2. **Project-local venv** — `.venv/bin/python3` in the project directory
+3. **Shell-activated venv** — `$VIRTUAL_ENV/bin/python3` if a venv is active
+4. **System python3** — First `python3` on `PATH`
+
+If no venv exists, the launcher creates one automatically using the resolved Python interpreter and installs dependencies from `requirements.txt` (or `pyproject.toml` if no requirements file exists).
+
+> **Tip**: pyenv resolution is preferred because it's version-pinned and reproducible. If you use pyenv, set a project Python with `pyenv local 3.12.x` and the launcher will pick it up automatically. You can also create a project venv with `pyenv exec python -m venv .venv` to pin the interpreter.
+
+## Usage
 
 ```bash
-./discordian.sh -d -c /path/to/config.ini -f /path/to/base/folder
+# Foreground (manual, systemd)
+./discordian.sh -c config.ini
+
+# Daemon mode (cron, background)
+./discordian.sh -d -c config.ini
+
+# Specify project directory explicitly
+./discordian.sh -d -c production.ini -f /opt/discordianai
+
+# Install and enable a systemd user service
+./discordian.sh --install-systemd bot.ini
 ```
 
-This command will run the bot in daemon mode, using the configuration file at `/path/to/config.ini` and the base folder at `/path/to/base/folder`.
+### Options
 
-> **Note:** Daemon/background mode is handled by the `discordian.sh` shell script, which supports `-d/--daemon`, `-c/--config`, and `-f/--folder` arguments. The Python code now supports `--folder` for base directory resolution of config and log files.
+| Flag | Long form | Description |
+|------|-----------|-------------|
+| `-d` | `--daemon` | Run in background, redirect output to `bot.log` |
+| `-c` | `--config` | Configuration file (default: `bot.ini`) |
+| `-f` | `--folder` | Project directory (default: script location) |
+| | `--install-systemd` | Generate and install a systemd user service for the given config file, then exit |
+| `-h` | `--help` | Show usage information |
+
+## Running with Cron
+
+For daily restarts, add a cron entry that runs the launcher in daemon mode:
+
+```bash
+# Restart the bot daily at 4:00 AM
+0 4 * * * /path/to/DiscordianAI/discordian.sh -d -c bot.ini -f /path/to/DiscordianAI
+```
+
+The `-d` flag runs the bot in the background with output sent to `bot.log` in the project directory. The `-f` flag ensures the working directory is set correctly regardless of cron's `$HOME` default.
+
+> **Important**: Cron environments have minimal `PATH`. If you use pyenv or Homebrew Python, make sure your `PATH` is set in the crontab or in a wrapper script. The launcher checks pyenv automatically, but pyenv must be on `PATH` for `command -v pyenv` to find it.
+
+## Running with systemd
+
+### Quick setup (recommended)
+
+The launcher can generate and install a systemd user service automatically:
+
+```bash
+./discordian.sh --install-systemd bot.ini
+```
+
+This command:
+
+1. Derives the instance name from the config file (`bot.ini` → `discordian-bot@bot`)
+2. Auto-detects paths from the script's location
+3. Builds a `PATH` that includes pyenv and Homebrew (detects `brew --prefix` automatically)
+4. Writes the unit file to `~/.config/systemd/user/`
+5. Runs `daemon-reload` and enables the service
+6. Prints management commands
+
+The config file name (without `.ini`) becomes the systemd instance name. `--install-systemd bot.ini` creates `discordian-bot@bot.service`, `--install-systemd production.ini` creates `discordian-bot@prod.service`.
+
+### Manual setup
+
+A template unit file is included in `contrib/systemd/discordian-bot@.service`. To install manually:
+
+1. **Copy** the template to your systemd user directory:
+   ```bash
+   mkdir -p ~/.config/systemd/user
+   cp contrib/systemd/discordian-bot@.service ~/.config/systemd/user/
+   ```
+
+2. **Edit the copy** — replace all `/path/to/DiscordianAI` with your actual installation path, and adjust `PATH` to include pyenv or Homebrew if needed (the `--install-systemd` flag does this automatically)
+
+3. **Reload and enable**:
+   ```bash
+   systemctl --user daemon-reload
+   systemctl --user enable --now discordian-bot@bot
+   ```
+
+### Advantages over cron
+
+| Feature | Cron | Systemd |
+|---------|------|---------|
+| Auto-restart on crash | ❌ | ✅ (`Restart=on-failure`) |
+| Restart delay | ✗ | ✅ (`RestartSec=15`) |
+| Proper logging | File only | `journalctl` + file |
+| Service management | `crontab -e` | `systemctl --user` |
+| Startup ordering | ✗ | ✅ (`After=network-online.target`) |
+
+### Switching from cron to systemd
+
+1. **Remove** the cron entry: `crontab -e` and delete the DiscordianAI line
+2. **Install** the systemd service: `./discordian.sh --install-systemd bot.ini`
+3. Done. The service starts and enables automatically.
+
+Both methods can coexist, but that would start two instances. Pick one.
+
+## Process Management
+
+The launcher tracks the bot's PID in `.bot.pid` (in the project directory) and uses it for clean shutdown:
+
+1. If a `.bot.pid` file exists, it sends `SIGTERM` and waits up to 10 seconds
+2. If the process doesn't stop, it sends `SIGKILL`
+3. It also scans for stray processes matching `src.main --conf`
+
+This ensures clean restarts whether triggered by cron, systemd, or manual invocation.
+
+## Venv Details
+
+The project-local `.venv/` directory is created automatically on first run if it doesn't exist. It's excluded from git via `.gitignore`.
+
+To recreate the venv (e.g., after a Python version change):
+
+```bash
+rm -rf .venv
+./discordian.sh -c config.ini   # Will bootstrap a fresh venv
+```
+
+To force a specific Python version for the venv:
+
+```bash
+# With pyenv (preferred — version-pinned, reproducible)
+pyenv install 3.12.12
+pyenv local 3.12.12
+rm -rf .venv
+./discordian.sh -c config.ini   # Will use pyenv's Python automatically
+
+# Without pyenv — create venv manually
+/usr/bin/python3.12 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+./discordian.sh -c config.ini
+```
+
+## Troubleshooting
+
+**"No python3 found"**
+- Install Python 3.12+ or create a venv manually
+- If using pyenv, ensure `pyenv` is on `PATH` (add to `~/.bashrc` or crontab)
+
+**"Python 3.12+ required"**
+- The resolved Python is too old. Check which one the launcher found:
+  ```bash
+  ./discordian.sh -c config.ini 2>&1 | head -5
+  ```
+- Install a newer Python or point pyenv to 3.12+
+
+**"Missing core dependencies"**
+- Repair the venv:
+  ```bash
+  .venv/bin/pip install -r requirements.txt
+  ```
+- Or delete and let the launcher recreate:
+  ```bash
+  rm -rf .venv && ./discordian.sh -c config.ini
+  ```
+
+**"Bot crashed on startup"**
+- Check `bot.log` for the error
+- Common causes: invalid config, missing API keys, network issues
+
+**Wrong Python being used**
+- The launcher prints which Python it resolved at startup
+- Check the resolution order (pyenv → venv → system) and ensure your preferred Python is first
+
+**systemd service won't start**
+- Check status: `systemctl --user status discordian-bot@bot`
+- Check logs: `journalctl --user -u discordian-bot@bot -f`
+- Verify paths in the unit file match your installation
+- Re-generate with `./discordian.sh --install-systemd bot.ini` to auto-detect paths


### PR DESCRIPTION
## Problem

The `discordian.sh` launcher had three compounding failures:

1. **No `cd` to project directory** — Cron runs from `$HOME`, causing `ModuleNotFoundError: No module named 'src'` because Python resolves the module import before the code can use the `--folder` flag
2. **Hardcoded linuxbrew PATH** — Only worked on one system, broke anywhere else
3. **No crash recovery** — Cron fires once daily; if the bot crashes, it stays down for up to 24 hours

## Changes

### `discordian.sh` — Complete rewrite

- **Python resolution chain**: pyenv → project `.venv` → shell `$VIRTUAL_ENV` → system `python3` (pyenv preferred for version pinning)
- **Automatic venv bootstrapping**: creates `.venv/` with dependencies if none exists
- **Always `cd` into project directory**: fixes the ModuleNotFoundError root cause
- **PID-based process management**: graceful shutdown (SIGTERM → 10s wait → SIGKILL), stray process cleanup
- **Startup health check**: daemon mode waits 3 seconds and confirms the process survived
- **Backward-compatible flags**: `-d/-c/-f` all work the same, added `-h` for help
- **Python 3.12+ version check**: fails clean with a clear message on older Python

### `contrib/systemd/discordian-bot@.service` — New

Template systemd user unit for auto-restart deployments. Instance name maps to config file (`discordian-bot@bot` → `bot.ini`). Includes setup instructions in comments.

### `docs/Daemon.md` — Rewritten

- Documents the Python resolution order (pyenv first) and venv bootstrapping
- Covers both cron and systemd deployment paths
- Troubleshooting section for common startup failure modes
- Venv management (recreating, pinning Python versions)

### `README.md` — Updated

- Added "Running with the launcher script" section with examples
- Explains Python resolution order and automatic venv creation
- Links to Daemon.md for deployment details

### `CHANGELOG.md` — Updated

- Added Unreleased section documenting all fixes and additions

### `.gitignore` — Updated

- Added `.bot.pid` for PID file tracking

## Testing

Tested on Ubuntu (WSL2) with pyenv Python 3.12.12:
- ✅ Manual foreground launch
- ✅ Daemon mode launch
- ✅ Venv auto-creation from pyenv Python
- ✅ Dependency verification (discord.py, openai, httpx)
- ✅ Process management (graceful shutdown, stray cleanup)
- ✅ Systemd foreground mode with auto-restart

## Notes

- The old hardcoded `/home/linuxbrew/.linuxbrew/bin` PATH is removed — pyenv and system PATH are checked automatically
- Pyenv is checked first in the resolution order for version-pinned, reproducible deployments
- No system-specific or bot-specific content in this PR
- The `.venv/` directory is already in `.gitignore` and excluded from the commit